### PR TITLE
pdate control unit ports to better fit style guide

### DIFF
--- a/src_sw/proj/src/TopLevel/Control/control.vhd
+++ b/src_sw/proj/src/TopLevel/Control/control.vhd
@@ -11,15 +11,15 @@ use IEEE.std_logic_1164.all;
 entity control_unit is
     port (
         -- Instruction inputs
-        i_opcode : in std_logic_vector(5 downto 0);  -- Opcode from MIPS instruction memory (s_Instr[31-26])
-        i_funct  : in std_logic_vector(5 downto 0);  -- Function code for certain instructions with same opcode
-        i_rt     : in std_logic_vector(4 downto 0);  -- RT field helps determine branch type   
+        i_Opcode : in std_logic_vector(5 downto 0);  -- Opcode from MIPS instruction memory (s_Instr[31-26])
+        i_Funct  : in std_logic_vector(5 downto 0);  -- Function code for certain instructions with same opcode
+        i_Rt     : in std_logic_vector(4 downto 0);  -- RT field helps determine branch type   
 
         -- Control signal outputs
         o_RegWr       : out std_logic;  -- Register write enable
         o_RegDst      : out std_logic_vector(1 downto 0);  -- Register destination
-        o_sign_ext_en : out std_logic;  -- Sign extension enable
-        o_jump        : out std_logic_vector(1 downto 0);  -- Controls address for jump
+        o_SignExtEnable : out std_logic;  -- Sign extension enable
+        o_Jump        : out std_logic_vector(1 downto 0);  -- Controls address for jump
         o_MemSel      : out std_logic_vector(1 downto 0);  -- Select write back source, either data memory, ALU, or PC+4
         o_branchCtl   : out std_logic;  -- ANDed with branch signal from ALU to determine if branch is taken
         o_BranchType  : out std_logic_vector(2 downto 0);  -- Tells Branch control what branch type we want to do
@@ -35,55 +35,55 @@ architecture dataflow of control_unit is
 begin
 
     -- Register destination            
-    o_RegDst <= "01" when i_opcode = b"000000" else  -- R-type (rd)          
-                "10" when (i_opcode = b"000001" and (i_rt = b"10001" or i_rt = b"10000")) or i_opcode = b"000011" else  -- jal or branch and link
+    o_RegDst <= "01" when i_Opcode = b"000000" else  -- R-type (rd)          
+                "10" when (i_Opcode = b"000001" and (i_Rt = b"10001" or i_Rt = b"10000")) or i_Opcode = b"000011" else  -- jal or branch and link
                 "00";                   -- else, use rt
 
     -- Adjust jump signals based on function code
     -- Jr is an R-type so opcode is 0, but we don't want to set jump for every r-type
-    o_jump <= "10" when (i_funct = b"001000" and i_opcode = b"000000") else  -- jr
-              "01" when i_opcode = b"000010" else  --j
-              "01" when i_opcode = b"000011" else  --jal
+    o_Jump <= "10" when (i_Funct = b"001000" and i_Opcode = b"000000") else  -- jr
+              "01" when i_Opcode = b"000010" else  --j
+              "01" when i_Opcode = b"000011" else  --jal
               "00";                     --Everything else
 
     -- Register write enable
     --TODO fix this to work right with bgezal, bltzal, and jr
-    s_RegWrite <= '0' when i_funct = b"001000" and i_opcode = b"000000" else
-                  '1' when o_jump = b"01" and o_RegDst = b"10" else
+    s_RegWrite <= '0' when i_Funct = b"001000" and i_Opcode = b"000000" else
+                  '1' when o_Jump = b"01" and o_RegDst = b"10" else
                   '0' when o_RegDst = b"10" else
-                  '0' when i_opcode = b"000010" or
-                  i_opcode = b"000100" or
-                  i_opcode = b"000101" or
-                  i_opcode = b"000110" or
-                  i_opcode = b"000111" or
-                  i_opcode = b"000100" or
-                  i_opcode = b"000101" or
-                  i_opcode = b"101011" else
-                  '0' when i_opcode = b"000001" and o_jump = b"00" else
+                  '0' when i_Opcode = b"000010" or
+                  i_Opcode = b"000100" or
+                  i_Opcode = b"000101" or
+                  i_Opcode = b"000110" or
+                  i_Opcode = b"000111" or
+                  i_Opcode = b"000100" or
+                  i_Opcode = b"000101" or
+                  i_Opcode = b"101011" else
+                  '0' when i_Opcode = b"000001" and o_Jump = b"00" else
                   '1';
     o_RegWr <= s_RegWrite;
 
-    with i_opcode select
+    with i_Opcode select
         -- Sign extension enable
-        o_sign_ext_en <= '0' when b"000000" | b"001100" | b"001110" | b"001101" | b"000010" | b"000011",
+        o_SignExtEnable <= '0' when b"000000" | b"001100" | b"001110" | b"001101" | b"000010" | b"000011",
         '1'                  when others;
 
-    with i_opcode select
+    with i_Opcode select
         -- Select write back source, either data memory, ALU, or PC+4          
         o_MemSel <= "11" when b"001111",
         "01"             when b"100011",              -- lw
         "10"             when b"000011" | b"000001",  -- branch and jal
         "00"             when others;                 -- else, use ALU result
 
-    p_BranchType : process(i_rt, i_opcode)
+    p_BranchType : process(i_Rt, i_Opcode)
     begin
-        case i_opcode is
+        case i_Opcode is
             when b"000100" => o_BranchType <= b"000";
             when b"000101" => o_BranchType <= b"001";
             when b"000001" =>
-                if (i_rt = b"00001" or i_rt = b"10001") then
+                if (i_Rt = b"00001" or i_Rt = b"10001") then
                     o_BranchType <= b"010";
-                elsif (i_rt = b"10000" or i_rt = b"00000") then
+                elsif (i_Rt = b"10000" or i_Rt = b"00000") then
                     o_BranchType <= b"101";
                 end if;
             when b"000111" => o_BranchType <= b"011";
@@ -93,12 +93,12 @@ begin
         end case;
     end process;
 
-    with i_opcode select
+    with i_Opcode select
         -- ALU source
         o_ALUSrc <= '0' when b"000000" | b"000100" | b"000101",
         '1'             when others;
 
-    with i_opcode select
+    with i_Opcode select
         -- Determine ALU operation
         o_ALUOp <= "000" when b"000000",
         "001"            when b"001000",
@@ -110,18 +110,18 @@ begin
         "000"            when others;
 
     -- Data Memory write enable
-    with i_opcode select
+    with i_Opcode select
         o_MemWr <= '1' when b"101011",  -- sw
         '0'            when others;
 
     -- Halt instruction: Stop program execution
-    with i_opcode select
+    with i_Opcode select
         o_Halt <= '1' when b"010100",
         '0'           when others;
 
-    p_branch : process(i_opcode, s_RegWrite)
+    p_branch : process(i_Opcode, s_RegWrite)
     begin
-        case? i_opcode is
+        case? i_Opcode is
             when b"000000" =>
                 if s_RegWrite = '0' then
                     o_branchCtl <= '1';

--- a/src_sw/proj/src/TopLevel/MIPS_Processor.vhd
+++ b/src_sw/proj/src/TopLevel/MIPS_Processor.vhd
@@ -193,15 +193,15 @@ architecture structure of MIPS_Processor is
 
     component control_unit is
         port (
-            i_opcode      : in  std_logic_vector(5 downto 0);
-            i_funct       : in  std_logic_vector(5 downto 0);
-            i_rt          : in  std_logic_vector(4 downto 0);
+            i_Opcode      : in  std_logic_vector(5 downto 0);
+            i_Funct       : in  std_logic_vector(5 downto 0);
+            i_Rt          : in  std_logic_vector(4 downto 0);
             o_RegWr       : out std_logic;
             o_RegDst      : out std_logic_vector(1 downto 0);
-            o_sign_ext_en : out std_logic;
-            o_jump        : out std_logic_vector(1 downto 0);
+            o_SignExtEnable : out std_logic;
+            o_Jump        : out std_logic_vector(1 downto 0);
             o_MemSel      : out std_logic_vector(1 downto 0);
-            o_branchCtl   : out std_logic;
+            o_BranchCtl   : out std_logic;
             o_BranchType  : out std_logic_vector(2 downto 0);
             o_ALUSrc      : out std_logic;
             o_ALUOp       : out std_logic_vector(2 downto 0);

--- a/src_sw/proj/test/tb_control.vhd
+++ b/src_sw/proj/test/tb_control.vhd
@@ -15,17 +15,17 @@ architecture structural of tb_control_unit is
     component control_unit is
         port (
             -- Instruction inputs
-            i_opcode : in std_logic_vector(5 downto 0);  -- Opcode from MIPS instruction memory (s_Instr[31-26])
-            i_funct  : in std_logic_vector(5 downto 0);  -- Function code for certain instructions with same opcode
-            i_rt     : in std_logic_vector(4 downto 0);  -- RT field helps determine branch type   
+            i_Opcode : in std_logic_vector(5 downto 0);  -- Opcode from MIPS instruction memory (s_Instr[31-26])
+            i_Funct  : in std_logic_vector(5 downto 0);  -- Function code for certain instructions with same opcode
+            i_Rt     : in std_logic_vector(4 downto 0);  -- RT field helps determine branch type   
 
             -- Control signal outputs
             o_RegWr       : out std_logic;  -- Register write enable
             o_RegDst      : out std_logic_vector(1 downto 0);  -- Register destination
-            o_sign_ext_en : out std_logic;  -- Sign extension enable
-            o_jump        : out std_logic_vector(1 downto 0);  -- Controls address for jump
+            o_SignExtEnable : out std_logic;  -- Sign extension enable
+            o_Jump        : out std_logic_vector(1 downto 0);  -- Controls address for jump
             o_MemSel      : out std_logic_vector(1 downto 0);  -- Select write back source, either data memory, ALU, or PC+4
-            o_branchCtl   : out std_logic;  -- ANDed with branch signal from ALU to determine if branch is taken
+            o_BranchCtl   : out std_logic;  -- ANDed with branch signal from ALU to determine if branch is taken
             o_BranchType  : out std_logic_vector(2 downto 0);  -- Tells Branch control what branch type we want to do
             o_ALUSrc      : out std_logic;  -- ALU source
             o_ALUOp       : out std_logic_vector(2 downto 0);  -- Used by ALU control to determine ALU operation
@@ -55,15 +55,15 @@ architecture structural of tb_control_unit is
 
 begin
     DUT0 : control_unit port map(
-        i_opcode      => s_iOpcode,
-        i_funct       => s_iFunct,
-        i_rt          => s_iRt,
+        i_Opcode      => s_iOpcode,
+        i_Funct       => s_iFunct,
+        i_Rt          => s_iRt,
         o_RegWr       => s_oRegWr,
         o_RegDst      => s_oRegDst,
-        o_sign_ext_en => s_oSignExtEn,
-        o_jump        => s_oJump,
+        o_SignExtEnable => s_oSignExtEn,
+        o_Jump        => s_oJump,
         o_MemSel      => s_oMemSel,
-        o_branchCtl   => s_oBranchCtl,
+        o_BranchCtl   => s_oBranchCtl,
         o_BranchType  => s_oBranchType,
         o_ALUSrc      => s_oALUSrc,
         o_ALUOp       => s_oALUOp,


### PR DESCRIPTION
This pull request includes several changes to the `control.vhd`, `MIPS_Processor.vhd`, and `tb_control.vhd` files to standardize the naming conventions of signals and ports. The changes primarily focus on updating the naming of inputs and outputs to follow a consistent camel case format.

### Standardization of Naming Conventions:

* Updated the naming of input ports `i_opcode`, `i_funct`, and `i_rt` to `i_Opcode`, `i_Funct`, and `i_Rt` respectively in the `control.vhd` file.
* Updated the naming of output ports `o_sign_ext_en` and `o_jump` to `o_SignExtEnable` and `o_Jump` respectively in the `control.vhd` file.
* Modified the internal signal names in the `control.vhd` architecture to match the updated input and output port names. [[1]](diffhunk://#diff-2f6224b7bb3f9f3d9b5035ed1d738490da692b41488071ff7a618bb01f481bd3L38-R86) [[2]](diffhunk://#diff-2f6224b7bb3f9f3d9b5035ed1d738490da692b41488071ff7a618bb01f481bd3L96-R101) [[3]](diffhunk://#diff-2f6224b7bb3f9f3d9b5035ed1d738490da692b41488071ff7a618bb01f481bd3L113-R124)
* Updated the component instantiation in the `MIPS_Processor.vhd` file to use the new input and output port names.
* Updated the testbench `tb_control.vhd` to reflect the new input and output port names for the `control_unit` component. [[1]](diffhunk://#diff-1e9f4dfea9b5902536950fde3e0b130a6227c273cf543c229d47da44c387f253L18-R28) [[2]](diffhunk://#diff-1e9f4dfea9b5902536950fde3e0b130a6227c273cf543c229d47da44c387f253L58-R66)