### PR TITLE
ConnerOhnesorge

### DIFF
--- a/src_hw/proj/src/MidLevel/Pipeline_EX_MEM.vhd
+++ b/src_hw/proj/src/MidLevel/Pipeline_EX_MEM.vhd
@@ -8,22 +8,22 @@ entity EX_MEM is
         i_RST      : in  std_logic;    
         i_stall    : in  std_logic;     
         i_ALU      : in  std_logic_vector(31 downto 0);
-        o_ALU      : out std_logic_vector(31 downto 0);
         i_B        : in  std_logic_vector(31 downto 0); 
-        o_B        : out std_logic_vector(31 downto 0);  
         i_WrAddr   : in  std_logic_vector(4 downto 0); 
-        o_WrAddr   : out std_logic_vector(4 downto 0);
         i_MemWr    : in  std_logic;  
-        o_MemWr    : out std_logic;   
         i_MemtoReg : in  std_logic;    
-        o_MemtoReg : out std_logic;
         i_Halt     : in  std_logic;     
-        o_Halt     : out std_logic;
         i_RegWr    : in  std_logic;     
-        o_RegWr    : out std_logic;
         i_jal      : in  std_logic;    
-        o_jal      : out std_logic;
         i_PC4      : in  std_logic_vector(31 downto 0);  
+        o_ALU      : out std_logic_vector(31 downto 0);
+        o_B        : out std_logic_vector(31 downto 0);  
+        o_WrAddr   : out std_logic_vector(4 downto 0);
+        o_MemWr    : out std_logic;   
+        o_MemtoReg : out std_logic;
+        o_Halt     : out std_logic;
+        o_RegWr    : out std_logic;
+        o_jal      : out std_logic;
         o_PC4      : out std_logic_vector(31 downto 0)
         );
     

--- a/src_hw/proj/src/MidLevel/Pipeline_ID_EX.vhd
+++ b/src_hw/proj/src/MidLevel/Pipeline_ID_EX.vhd
@@ -2,6 +2,7 @@ library IEEE;
 use IEEE.std_logic_1164.all;
 
 entity ID_EX is
+        
         port (
                 i_CLK          : in  std_logic;
                 i_RST          : in  std_logic;
@@ -39,6 +40,7 @@ entity ID_EX is
                 o_halt         : out std_logic;
                 o_memRd        : out std_logic
                 );
+        
 end ID_EX;
 
 architecture structural of ID_EX is

--- a/src_hw/proj/src/MidLevel/Pipeline_MEM_WB.vhd
+++ b/src_hw/proj/src/MidLevel/Pipeline_MEM_WB.vhd
@@ -8,20 +8,20 @@ entity MEM_WB is
         i_RST      : in  std_logic;
         i_stall    : in  std_logic;
         i_ALU      : in  std_logic_vector(31 downto 0);
-        o_ALU      : out std_logic_vector(31 downto 0);
         i_Mem      : in  std_logic_vector(31 downto 0);
-        o_Mem      : out std_logic_vector(31 downto 0);
         i_WrAddr   : in  std_logic_vector(4 downto 0);
-        o_WrAddr   : out std_logic_vector(4 downto 0);
         i_MemtoReg : in  std_logic;
-        o_MemtoReg : out std_logic;
         i_Halt     : in  std_logic;
-        o_Halt     : out std_logic;
         i_RegWr    : in  std_logic;
-        o_RegWr    : out std_logic;
         i_jal      : in  std_logic;
-        o_jal      : out std_logic;
         i_PC4      : in  std_logic_vector(31 downto 0);
+        o_ALU      : out std_logic_vector(31 downto 0);
+        o_Mem      : out std_logic_vector(31 downto 0);
+        o_WrAddr   : out std_logic_vector(4 downto 0);
+        o_MemtoReg : out std_logic;
+        o_Halt     : out std_logic;
+        o_RegWr    : out std_logic;
+        o_jal      : out std_logic;
         o_PC4      : out std_logic_vector(31 downto 0)
         );
 

--- a/src_hw/proj/src/TopLevel/MIPS_Processor.vhd
+++ b/src_hw/proj/src/TopLevel/MIPS_Processor.vhd
@@ -70,7 +70,7 @@ architecture structure of MIPS_Processor is
         port (
             i_CLK          : in  std_logic;
             i_RST          : in  std_logic;
-            i_stall        : in  std_logic;
+            i_stall        : in  std_logic;                     --stall control
             i_PC4          : in  std_logic_vector(31 downto 0);
             i_readA        : in  std_logic_vector(31 downto 0);
             i_readB        : in  std_logic_vector(31 downto 0);
@@ -130,28 +130,29 @@ architecture structure of MIPS_Processor is
             o_jal      : out std_logic;
             o_PC4      : out std_logic_vector(31 downto 0)
             );
+
     end component;
 
     component MEM_WB is
         port (
-            i_CLK      : in  std_logic;  -- Clock input
-            i_RST      : in  std_logic;  -- Reset input
-            i_stall    : in  std_logic;  -- Write enable input
-            i_ALU      : in  std_logic_vector(31 downto 0);  -- ALU value input
-            o_ALU      : out std_logic_vector(31 downto 0);  -- ALU value output
-            i_Mem      : in  std_logic_vector(31 downto 0);  --Mem value
-            o_Mem      : out std_logic_vector(31 downto 0);  --Mem value
-            i_WrAddr   : in  std_logic_vector(4 downto 0);  --write address to register file
-            o_WrAddr   : out std_logic_vector(4 downto 0);
-            i_MemtoReg : in  std_logic;  --memory vs alu signal
-            o_MemtoReg : out std_logic;
-            i_Halt     : in  std_logic;  --halt signal
-            o_Halt     : out std_logic;
-            i_RegWr    : in  std_logic;  --write enable for reg file
-            o_RegWr    : out std_logic;
+            i_CLK      : in  std_logic;
+            i_RST      : in  std_logic;
+            i_stall    : in  std_logic;
+            i_ALU      : in  std_logic_vector(31 downto 0);
+            i_Mem      : in  std_logic_vector(31 downto 0);
+            i_WrAddr   : in  std_logic_vector(4 downto 0);
+            i_MemtoReg : in  std_logic;
+            i_Halt     : in  std_logic;
+            i_RegWr    : in  std_logic;
             i_jal      : in  std_logic;
+            i_PC4      : in  std_logic_vector(31 downto 0);
+            o_ALU      : out std_logic_vector(31 downto 0);
+            o_Mem      : out std_logic_vector(31 downto 0);
+            o_WrAddr   : out std_logic_vector(4 downto 0);
+            o_MemtoReg : out std_logic;
+            o_Halt     : out std_logic;
+            o_RegWr    : out std_logic;
             o_jal      : out std_logic;
-            i_PC4      : in  std_logic_vector(31 downto 0);  --pc+4
             o_PC4      : out std_logic_vector(31 downto 0)
             );
     end component;
@@ -341,7 +342,7 @@ begin
     s_DMemAddr  <= s_MEMALU;
     s_RegWr     <= s_WBRegWr;
     s_RegWrAddr <= s_WBrtrd;
-    s_NotClk   <= not iCLK;
+    s_NotClk    <= not iCLK;
 
     instRegFile : RegisterFile
         port map(

--- a/src_sw/proj/src/LowLevel/mux32t1.vhd
+++ b/src_sw/proj/src/LowLevel/mux32t1.vhd
@@ -15,7 +15,7 @@ end entity mux32t1;
 
 architecture behavior of mux32t1 is
 begin
-    -- Selects the output based on the input select signal
+    
     with i_S select o_O <=
         i_I(0)                             when "00000",
         i_I(01)                            when "00001",  -- when the input select is "00001" the output is "i_I(1)"

--- a/src_sw/proj/src/LowLevel/mux4t1_N.vhd
+++ b/src_sw/proj/src/LowLevel/mux4t1_N.vhd
@@ -8,7 +8,7 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-entity mux4t1_n is
+entity mux4t1_N is
     generic (
         n : integer := 32  -- Generic of type integer for input/output data width. Default value is 32.
         );
@@ -22,9 +22,9 @@ entity mux4t1_n is
         o_o  : out std_logic_vector(n - 1 downto 0)  -- Output data width is N.
         );
     
-end entity mux4t1_n;
+end entity mux4t1_N;
 
-architecture structural of mux4t1_n is
+architecture structural of mux4t1_N is
 
     component mux4t1 is
         port (

--- a/src_sw/proj/src/LowLevel/nandg32.vhd
+++ b/src_sw/proj/src/LowLevel/nandg32.vhd
@@ -7,15 +7,20 @@
 
 library IEEE;
 use IEEE.std_logic_1164.all;
+
 entity nandg32 is
-    port(i_A : in  std_logic_vector(31 downto 0);
-         i_B : in  std_logic_vector(31 downto 0);
-         o_F : out std_logic_vector(31 downto 0));
+    
+    port(
+        i_A : in  std_logic_vector(31 downto 0);
+        i_B : in  std_logic_vector(31 downto 0);
+        o_F : out std_logic_vector(31 downto 0)
+        );
+    
 end nandg32;
+
 architecture dataflow of nandg32 is
 begin
     G1 : for i in 0 to 31 generate
         o_F(i) <= i_A(i) nand i_B(i);
     end generate;
 end dataflow;
-

--- a/src_sw/proj/src/LowLevel/norg32.vhd
+++ b/src_sw/proj/src/LowLevel/norg32.vhd
@@ -8,11 +8,15 @@
 library IEEE;
 use IEEE.std_logic_1164.all;
 entity norg32 is
+    
     port (
         i_A : in  std_logic_vector(31 downto 0);
         i_B : in  std_logic_vector(31 downto 0);
-        o_F : out std_logic_vector(31 downto 0));
+        o_F : out std_logic_vector(31 downto 0)
+    );
+    
 end norg32;
+
 architecture dataflow of norg32 is
 begin
     G1 : for i in 0 to 31 generate

--- a/src_sw/proj/src/LowLevel/org2.vhd
+++ b/src_sw/proj/src/LowLevel/org2.vhd
@@ -8,13 +8,17 @@
 library IEEE;
 use IEEE.std_logic_1164.all;
 use IEEE.numeric_std.all;
+
 entity org2 is
+
     port (
         i_a : in  std_logic;
         i_b : in  std_logic;
         o_f : out std_logic
         );
+
 end entity org2;
+
 architecture dataflow of org2 is
 begin
     o_f <= i_a or i_b;

--- a/src_sw/proj/src/LowLevel/org32.vhd
+++ b/src_sw/proj/src/LowLevel/org32.vhd
@@ -8,11 +8,15 @@
 library IEEE;
 use IEEE.std_logic_1164.all;
 entity org32 is
+    
     port (
         i_A : in  std_logic_vector(31 downto 0);
         i_B : in  std_logic_vector(31 downto 0);
-        o_F : out std_logic_vector(31 downto 0));
+        o_F : out std_logic_vector(31 downto 0)
+    );
+    
 end org32;
+
 architecture dataflow of org32 is
 begin
     G1 : for i in 0 to 31 generate

--- a/src_sw/proj/src/LowLevel/xorg2.vhd
+++ b/src_sw/proj/src/LowLevel/xorg2.vhd
@@ -8,13 +8,17 @@
 library IEEE;
 use IEEE.std_logic_1164.all;
 use IEEE.numeric_std.all;
+
 entity xorg2 is
+    
     port (
         i_A : in  std_logic;
         i_B : in  std_logic;
         o_F : out std_logic
         );
+    
 end xorg2;
+
 architecture dataflow of xorg2 is
 begin
     o_F <= i_A xor i_B;

--- a/src_sw/proj/src/LowLevel/xorg32.vhd
+++ b/src_sw/proj/src/LowLevel/xorg32.vhd
@@ -9,12 +9,15 @@ library IEEE;
 use IEEE.std_logic_1164.all;
 use IEEE.numeric_std.all;
 entity xorg32 is
+    
     port (
         i_A : in  std_logic_vector(31 downto 0);  -- input A
         i_B : in  std_logic_vector(31 downto 0);  -- input B
         o_F : out std_logic_vector(31 downto 0)   -- output F
         );
+    
 end xorg32;
+
 architecture dataflow of xorg32 is
 begin
     G1 : for i in 0 to 31 generate

--- a/src_sw/proj/src/MidLevel/Pipeline_EX_MEM.vhd
+++ b/src_sw/proj/src/MidLevel/Pipeline_EX_MEM.vhd
@@ -7,22 +7,22 @@ entity EX_MEM is
         i_CLK      : in  std_logic;   
         i_RST      : in  std_logic;    
         i_ALU      : in  std_logic_vector(31 downto 0);
-        o_ALU      : out std_logic_vector(31 downto 0);
         i_B        : in  std_logic_vector(31 downto 0); 
-        o_B        : out std_logic_vector(31 downto 0);  
         i_WrAddr   : in  std_logic_vector(4 downto 0); 
-        o_WrAddr   : out std_logic_vector(4 downto 0);
         i_MemWr    : in  std_logic;  
-        o_MemWr    : out std_logic;   
         i_MemtoReg : in  std_logic;    
-        o_MemtoReg : out std_logic;
         i_Halt     : in  std_logic;     
-        o_Halt     : out std_logic;
         i_RegWr    : in  std_logic;     
-        o_RegWr    : out std_logic;
         i_jal      : in  std_logic;    
-        o_jal      : out std_logic;
         i_PC4      : in  std_logic_vector(31 downto 0);  
+        o_ALU      : out std_logic_vector(31 downto 0);
+        o_B        : out std_logic_vector(31 downto 0);  
+        o_WrAddr   : out std_logic_vector(4 downto 0);
+        o_MemWr    : out std_logic;   
+        o_MemtoReg : out std_logic;
+        o_Halt     : out std_logic;
+        o_RegWr    : out std_logic;
+        o_jal      : out std_logic;
         o_PC4      : out std_logic_vector(31 downto 0)
         );
     

--- a/src_sw/proj/src/MidLevel/Pipeline_ID_EX.vhd
+++ b/src_sw/proj/src/MidLevel/Pipeline_ID_EX.vhd
@@ -2,42 +2,40 @@ library IEEE;
 use IEEE.std_logic_1164.all;
 
 entity ID_EX is
+        
         port (
-                i_CLK          : in  std_logic;
-                i_RST          : in  std_logic;
-                i_PC4          : in  std_logic_vector(31 downto 0);
-                i_readA        : in  std_logic_vector(31 downto 0);
-                i_readB        : in  std_logic_vector(31 downto 0);
-                i_signExtImmed : in  std_logic_vector(31 downto 0);
-                i_IDRt         : in  std_logic_vector(4 downto 0);
-                i_IDRD         : in  std_logic_vector(4 downto 0);
-                i_RegDst       : in  std_logic;
-                i_RegWrite     : in  std_logic;
-                i_memToReg     : in  std_logic;
-                i_MemWrite     : in  std_logic;
-                i_ALUSrc       : in  std_logic;
-                i_ALUOp        : in  std_logic_vector(3 downto 0);
-                i_jal          : in  std_logic;
-                i_halt         : in  std_logic;
-                i_RS           : in  std_logic_vector(4 downto 0);
-                i_memRd        : in  std_logic;
-                o_RS           : out std_logic_vector(4 downto 0);
-                o_PC4          : out std_logic_vector(31 downto 0);
-                o_readA        : out std_logic_vector(31 downto 0);
-                o_readB        : out std_logic_vector(31 downto 0);
-                o_signExtImmed : out std_logic_vector(31 downto 0);
-                o_Rt           : out std_logic_vector(4 downto 0); -- inst20_16
-                o_Rd           : out std_logic_vector(4 downto 0); -- inst15_11
-                o_RegDst       : out std_logic;
-                o_RegWrite     : out std_logic;
-                o_memToReg     : out std_logic;
-                o_MemWrite     : out std_logic;
-                o_ALUSrc       : out std_logic;
-                o_ALUOp        : out std_logic_vector(3 downto 0);
-                o_jal          : out std_logic;
-                o_halt         : out std_logic;
-                o_memRd        : out std_logic
+                i_CLK      : in  std_logic;
+                i_RST      : in  std_logic;
+                i_PC4      : in  std_logic_vector(31 downto 0);
+                i_readA    : in  std_logic_vector(31 downto 0);
+                i_readB    : in  std_logic_vector(31 downto 0);
+                i_ExtImm   : in  std_logic_vector(31 downto 0);
+                i_Rt       : in  std_logic_vector(4 downto 0);  -- 20-16
+                i_Rd       : in  std_logic_vector(4 downto 0);  -- 15-11
+                i_RegDst   : in  std_logic;
+                i_RegWrite : in  std_logic;
+                i_memToReg : in  std_logic;
+                i_MemWrite : in  std_logic;
+                i_ALUSrc   : in  std_logic;
+                i_ALUOp    : in  std_logic_vector(3 downto 0);
+                i_jal      : in  std_logic;
+                i_halt     : in  std_logic;
+                o_PC4      : out std_logic_vector(31 downto 0);
+                o_readA    : out std_logic_vector(31 downto 0);
+                o_readB    : out std_logic_vector(31 downto 0);
+                o_ExtImm   : out std_logic_vector(31 downto 0);
+                o_Rt       : out std_logic_vector(4 downto 0);  -- 20-16
+                o_Rd       : out std_logic_vector(4 downto 0);  -- 15-11
+                o_RegDst   : out std_logic;
+                o_RegWrite : out std_logic;
+                o_memToReg : out std_logic;
+                o_MemWrite : out std_logic;
+                o_ALUSrc   : out std_logic;
+                o_ALUOp    : out std_logic_vector(3 downto 0);
+                o_jal      : out std_logic;
+                o_halt     : out std_logic
                 );
+        
 end ID_EX;
 
 architecture structural of ID_EX is
@@ -101,8 +99,8 @@ begin
                         i_CLK => i_CLK,
                         i_RST => i_RST,
                         i_WE  => '1',
-                        i_D   => i_signExtImmed,
-                        o_Q   => o_signExtImmed
+                        i_D   => i_ExtImm,
+                        o_Q   => o_ExtImm
                         );
 
         instRs : dffg_N
@@ -111,18 +109,8 @@ begin
                         i_CLK => i_CLK,
                         i_RST => i_RST,
                         i_WE  => '1',
-                        i_D   => i_RS,
-                        o_Q   => o_RS);
-
-        instRtReg : dffg_N
-                generic map(N => 5)
-                port map(
-                        i_CLK => i_CLK,
-                        i_RST => i_RST,
-                        i_WE  => '1',
-                        i_D   => i_IDRt,
-                        o_Q   => o_Rt
-                        );
+                        i_D   => i_Rt,
+                        o_Q   => o_Rt);
 
         instRdReg : dffg_N
                 generic map(N => 5)
@@ -130,7 +118,7 @@ begin
                         i_CLK => i_CLK,
                         i_RST => i_RST,
                         i_WE  => '1',
-                        i_D   => i_IDRD,
+                        i_D   => i_Rd,
                         o_Q   => o_Rd
                         );
 
@@ -206,15 +194,6 @@ begin
                         i_WE  => '1',
                         i_D   => i_halt,
                         o_Q   => o_halt
-                        );
-
-        instMemoryRd : dffg
-                port map (
-                        i_CLK => i_CLK,
-                        i_RST => i_RST,
-                        i_WE  => '1',
-                        i_D   => i_memRd,
-                        o_Q   => o_memRd
                         );
 
 end structural;

--- a/src_sw/proj/src/MidLevel/Pipeline_MEM_WB.vhd
+++ b/src_sw/proj/src/MidLevel/Pipeline_MEM_WB.vhd
@@ -7,20 +7,20 @@ entity MEM_WB is
         i_CLK      : in  std_logic;
         i_RST      : in  std_logic;
         i_ALU      : in  std_logic_vector(31 downto 0);
-        o_ALU      : out std_logic_vector(31 downto 0);
         i_Mem      : in  std_logic_vector(31 downto 0);
-        o_Mem      : out std_logic_vector(31 downto 0);
         i_WrAddr   : in  std_logic_vector(4 downto 0);
-        o_WrAddr   : out std_logic_vector(4 downto 0);
         i_MemtoReg : in  std_logic;
-        o_MemtoReg : out std_logic;
         i_Halt     : in  std_logic;
-        o_Halt     : out std_logic;
         i_RegWr    : in  std_logic;
-        o_RegWr    : out std_logic;
         i_jal      : in  std_logic;
-        o_jal      : out std_logic;
         i_PC4      : in  std_logic_vector(31 downto 0);
+        o_ALU      : out std_logic_vector(31 downto 0);
+        o_Mem      : out std_logic_vector(31 downto 0);
+        o_WrAddr   : out std_logic_vector(4 downto 0);
+        o_MemtoReg : out std_logic;
+        o_Halt     : out std_logic;
+        o_RegWr    : out std_logic;
+        o_jal      : out std_logic;
         o_PC4      : out std_logic_vector(31 downto 0)
         );
 

--- a/src_sw/proj/src/TopLevel/MIPS_Processor.vhd
+++ b/src_sw/proj/src/TopLevel/MIPS_Processor.vhd
@@ -467,6 +467,8 @@ begin
             i_readB    => s_RegB,
             i_ExtImm   => s_immediate,
             i_RegDst   => s_RegDst,
+            i_Rt       => s_ID_Inst(20 downto 16),
+            i_Rd       => s_ID_Inst(15 downto 11),
             i_RegWrite => s_muxRegWr,
             i_memToReg => s_memToReg,
             i_MemWrite => s_muxMemWr,

--- a/src_sw/proj/src/TopLevel/MIPS_Processor.vhd
+++ b/src_sw/proj/src/TopLevel/MIPS_Processor.vhd
@@ -248,19 +248,6 @@ architecture structure of MIPS_Processor is
             );
     end component;
 
-    component ForwardUnit is
-        port (
-            i_EX_rs     : in  std_logic_vector(4 downto 0);
-            i_EX_rt     : in  std_logic_vector(4 downto 0);
-            i_MEM_rd    : in  std_logic_vector(4 downto 0);
-            i_WB_rd     : in  std_logic_vector(4 downto 0);
-            i_MEM_wb    : in  std_logic;
-            i_WB_wb     : in  std_logic;
-            o_Forward_A : out std_logic_vector(1 downto 0);
-            o_Forward_B : out std_logic_vector(1 downto 0)
-            );
-    end component;
-
     signal s_ALUOp, s_EXALUOp : std_logic_vector(3 downto 0);
 
     signal s_EX_rs, s_EXrt, s_EXrd, s_EXrtrd : std_logic_vector(4 downto 0);

--- a/src_sw/proj/src/TopLevel/MIPS_Processor.vhd
+++ b/src_sw/proj/src/TopLevel/MIPS_Processor.vhd
@@ -67,40 +67,36 @@ architecture structure of MIPS_Processor is
 
     component ID_EX is
         port (
-            i_CLK          : in  std_logic;
-            i_RST          : in  std_logic;
-            i_PC4          : in  std_logic_vector(31 downto 0);
-            i_readA        : in  std_logic_vector(31 downto 0);
-            i_readB        : in  std_logic_vector(31 downto 0);
-            i_signExtImmed : in  std_logic_vector(31 downto 0);
-            i_IDRt         : in  std_logic_vector(4 downto 0);
-            i_IDRD         : in  std_logic_vector(4 downto 0);
-            i_RegDst       : in  std_logic;
-            i_RegWrite     : in  std_logic;
-            i_memToReg     : in  std_logic;
-            i_MemWrite     : in  std_logic;
-            i_ALUSrc       : in  std_logic;
-            i_ALUOp        : in  std_logic_vector(3 downto 0);
-            i_jal          : in  std_logic;
-            i_halt         : in  std_logic;
-            i_RS           : in  std_logic_vector(4 downto 0);
-            i_memRd        : in  std_logic;
-            o_RS           : out std_logic_vector(4 downto 0);
-            o_PC4          : out std_logic_vector(31 downto 0);
-            o_readA        : out std_logic_vector(31 downto 0);
-            o_readB        : out std_logic_vector(31 downto 0);
-            o_signExtImmed : out std_logic_vector(31 downto 0);
-            o_Rt           : out std_logic_vector(4 downto 0);  -- inst20_16
-            o_Rd           : out std_logic_vector(4 downto 0);  -- inst15_11
-            o_RegDst       : out std_logic;
-            o_RegWrite     : out std_logic;
-            o_memToReg     : out std_logic;
-            o_MemWrite     : out std_logic;
-            o_ALUSrc       : out std_logic;
-            o_ALUOp        : out std_logic_vector(3 downto 0);
-            o_jal          : out std_logic;
-            o_halt         : out std_logic;
-            o_memRd        : out std_logic
+            i_CLK      : in  std_logic;
+            i_RST      : in  std_logic;
+            i_PC4      : in  std_logic_vector(31 downto 0);
+            i_readA    : in  std_logic_vector(31 downto 0);
+            i_readB    : in  std_logic_vector(31 downto 0);
+            i_ExtImm   : in  std_logic_vector(31 downto 0);
+            i_Rt       : in  std_logic_vector(4 downto 0);  -- 20-16
+            i_Rd       : in  std_logic_vector(4 downto 0);  -- 15-11
+            i_RegDst   : in  std_logic;
+            i_RegWrite : in  std_logic;
+            i_memToReg : in  std_logic;
+            i_MemWrite : in  std_logic;
+            i_ALUSrc   : in  std_logic;
+            i_ALUOp    : in  std_logic_vector(3 downto 0);
+            i_jal      : in  std_logic;
+            i_halt     : in  std_logic;
+            o_PC4      : out std_logic_vector(31 downto 0);
+            o_readA    : out std_logic_vector(31 downto 0);
+            o_readB    : out std_logic_vector(31 downto 0);
+            o_ExtImm   : out std_logic_vector(31 downto 0);
+            o_Rt       : out std_logic_vector(4 downto 0);  -- 20-16
+            o_Rd       : out std_logic_vector(4 downto 0);  -- 15-11
+            o_RegDst   : out std_logic;
+            o_RegWrite : out std_logic;
+            o_memToReg : out std_logic;
+            o_MemWrite : out std_logic;
+            o_ALUSrc   : out std_logic;
+            o_ALUOp    : out std_logic_vector(3 downto 0);
+            o_jal      : out std_logic;
+            o_halt     : out std_logic
             );
     end component;
 
@@ -109,22 +105,22 @@ architecture structure of MIPS_Processor is
             i_CLK      : in  std_logic;
             i_RST      : in  std_logic;
             i_ALU      : in  std_logic_vector(31 downto 0);
-            o_ALU      : out std_logic_vector(31 downto 0);
             i_B        : in  std_logic_vector(31 downto 0);
-            o_B        : out std_logic_vector(31 downto 0);
             i_WrAddr   : in  std_logic_vector(4 downto 0);
-            o_WrAddr   : out std_logic_vector(4 downto 0);
             i_MemWr    : in  std_logic;
-            o_MemWr    : out std_logic;
             i_MemtoReg : in  std_logic;
-            o_MemtoReg : out std_logic;
             i_Halt     : in  std_logic;
-            o_Halt     : out std_logic;
             i_RegWr    : in  std_logic;
-            o_RegWr    : out std_logic;
             i_jal      : in  std_logic;
-            o_jal      : out std_logic;
             i_PC4      : in  std_logic_vector(31 downto 0);
+            o_ALU      : out std_logic_vector(31 downto 0);
+            o_B        : out std_logic_vector(31 downto 0);
+            o_WrAddr   : out std_logic_vector(4 downto 0);
+            o_MemWr    : out std_logic;
+            o_MemtoReg : out std_logic;
+            o_Halt     : out std_logic;
+            o_RegWr    : out std_logic;
+            o_jal      : out std_logic;
             o_PC4      : out std_logic_vector(31 downto 0)
             );
     end component;
@@ -464,40 +460,34 @@ begin
 
     instIDEX : ID_EX
         port map(
-            i_CLK          => iCLK,
-            i_RST          => iRST,
-            i_PC4          => s_ID_PC4,
-            i_readA        => s_RegA,
-            i_readB        => s_RegB,
-            i_signExtImmed => s_immediate,
-            i_IDRt         => s_ID_Inst(20 downto 16),
-            i_IDRD         => s_ID_Inst(15 downto 11),
-            i_RegDst       => s_RegDst,
-            i_RegWrite     => s_muxRegWr,
-            i_memToReg     => s_memToReg,
-            i_MemWrite     => s_muxMemWr,
-            i_ALUSrc       => s_ALUSrc,
-            i_ALUOp        => s_ALUOp,
-            i_jal          => s_jal,
-            i_halt         => s_IDhalt,
-            i_RS           => s_ID_Inst(25 downto 21),
-            i_memRd        => s_ID_memRD,
-            o_RS           => s_EX_rs,
-            o_PC4          => s_EX_PC4,
-            o_readA        => s_EXA,
-            o_readB        => s_EXB,
-            o_signExtImmed => s_EXImmediate,
-            o_Rt           => s_EXrt,
-            o_Rd           => s_EXrd,
-            o_RegDst       => s_EXRegDst,
-            o_RegWrite     => s_EXRegWr,
-            o_memToReg     => s_EXmemToReg,
-            o_MemWrite     => s_EXMemWr,
-            o_ALUSrc       => s_EXALUSrc,
-            o_ALUOp        => s_EXALUOp,
-            o_jal          => s_EXjal,
-            o_halt         => s_EXhalt,
-            o_memRd        => s_EXMemRd
+            i_CLK      => iCLK,
+            i_RST      => iRST,
+            i_PC4      => s_ID_PC4,
+            i_readA    => s_RegA,
+            i_readB    => s_RegB,
+            i_ExtImm   => s_immediate,
+            i_RegDst   => s_RegDst,
+            i_RegWrite => s_muxRegWr,
+            i_memToReg => s_memToReg,
+            i_MemWrite => s_muxMemWr,
+            i_ALUSrc   => s_ALUSrc,
+            i_ALUOp    => s_ALUOp,
+            i_jal      => s_jal,
+            i_halt     => s_IDhalt,
+            o_PC4      => s_EX_PC4,
+            o_readA    => s_EXA,
+            o_readB    => s_EXB,
+            o_ExtImm   => s_EXImmediate,
+            o_Rt       => s_EXrt,
+            o_Rd       => s_EXrd,
+            o_RegDst   => s_EXRegDst,
+            o_RegWrite => s_EXRegWr,
+            o_memToReg => s_EXmemToReg,
+            o_MemWrite => s_EXMemWr,
+            o_ALUSrc   => s_EXALUSrc,
+            o_ALUOp    => s_EXALUOp,
+            o_jal      => s_EXjal,
+            o_halt     => s_EXhalt
             );
 
     instEXMEM : EX_MEM

--- a/src_sw/proj/src/TopLevel/MIPS_Processor.vhd
+++ b/src_sw/proj/src/TopLevel/MIPS_Processor.vhd
@@ -106,21 +106,21 @@ architecture structure of MIPS_Processor is
 
     component EX_MEM is
         port (
-            i_CLK      : in  std_logic;  
-            i_RST      : in  std_logic; 
-            i_ALU      : in  std_logic_vector(31 downto 0);  
-            o_ALU      : out std_logic_vector(31 downto 0);  
-            i_B        : in  std_logic_vector(31 downto 0);  
-            o_B        : out std_logic_vector(31 downto 0);  
-            i_WrAddr   : in  std_logic_vector(4 downto 0);  
+            i_CLK      : in  std_logic;
+            i_RST      : in  std_logic;
+            i_ALU      : in  std_logic_vector(31 downto 0);
+            o_ALU      : out std_logic_vector(31 downto 0);
+            i_B        : in  std_logic_vector(31 downto 0);
+            o_B        : out std_logic_vector(31 downto 0);
+            i_WrAddr   : in  std_logic_vector(4 downto 0);
             o_WrAddr   : out std_logic_vector(4 downto 0);
-            i_MemWr    : in  std_logic;  
-            o_MemWr    : out std_logic;  
-            i_MemtoReg : in  std_logic;  
+            i_MemWr    : in  std_logic;
+            o_MemWr    : out std_logic;
+            i_MemtoReg : in  std_logic;
             o_MemtoReg : out std_logic;
-            i_Halt     : in  std_logic;  
+            i_Halt     : in  std_logic;
             o_Halt     : out std_logic;
-            i_RegWr    : in  std_logic;  
+            i_RegWr    : in  std_logic;
             o_RegWr    : out std_logic;
             i_jal      : in  std_logic;
             o_jal      : out std_logic;
@@ -131,18 +131,18 @@ architecture structure of MIPS_Processor is
 
     component MEM_WB is
         port (
-            i_CLK      : in  std_logic; 
-            i_RST      : in  std_logic;  
-            i_ALU      : in  std_logic_vector(31 downto 0); 
-            i_Mem      : in  std_logic_vector(31 downto 0);  
-            i_WrAddr   : in  std_logic_vector(4 downto 0);  
-            i_MemtoReg : in  std_logic; 
-            i_Halt     : in  std_logic; 
-            i_RegWr    : in  std_logic;  
+            i_CLK      : in  std_logic;
+            i_RST      : in  std_logic;
+            i_ALU      : in  std_logic_vector(31 downto 0);
+            i_Mem      : in  std_logic_vector(31 downto 0);
+            i_WrAddr   : in  std_logic_vector(4 downto 0);
+            i_MemtoReg : in  std_logic;
+            i_Halt     : in  std_logic;
+            i_RegWr    : in  std_logic;
             i_jal      : in  std_logic;
-            i_PC4      : in  std_logic_vector(31 downto 0);  
-            o_ALU      : out std_logic_vector(31 downto 0); 
-            o_Mem      : out std_logic_vector(31 downto 0);  
+            i_PC4      : in  std_logic_vector(31 downto 0);
+            o_ALU      : out std_logic_vector(31 downto 0);
+            o_Mem      : out std_logic_vector(31 downto 0);
             o_WrAddr   : out std_logic_vector(4 downto 0);
             o_MemtoReg : out std_logic;
             o_Halt     : out std_logic;
@@ -179,26 +179,26 @@ architecture structure of MIPS_Processor is
 
     component FetchUnit is
         port (
-            i_PC4         : in  std_logic_vector(31 downto 0);  
-            i_branch_addr : in  std_logic_vector(31 downto 0);  
-            i_jump_addr   : in  std_logic_vector(31 downto 0);  
-            i_jr          : in  std_logic_vector(31 downto 0);  
-            i_jr_select   : in  std_logic;  
-            i_branch      : in  std_logic; 
+            i_PC4         : in  std_logic_vector(31 downto 0);
+            i_branch_addr : in  std_logic_vector(31 downto 0);
+            i_jump_addr   : in  std_logic_vector(31 downto 0);
+            i_jr          : in  std_logic_vector(31 downto 0);
+            i_jr_select   : in  std_logic;
+            i_branch      : in  std_logic;
             i_bne         : in  std_logic;
             i_A           : in  std_logic_vector(31 downto 0);
             i_B           : in  std_logic_vector(31 downto 0);
-            i_jump        : in  std_logic;  
+            i_jump        : in  std_logic;
             o_PC          : out std_logic_vector(31 downto 0);
-            o_jump_branch : out std_logic  
+            o_jump_branch : out std_logic
             );
     end component;
 
     component extender16t32 is
         port(
-            i_I : in  std_logic_vector(15 downto 0);  
-            i_C : in  std_logic;        
-            o_O : out std_logic_vector(31 downto 0)  
+            i_I : in  std_logic_vector(15 downto 0);
+            i_C : in  std_logic;
+            o_O : out std_logic_vector(31 downto 0)
             );
     end component;
 
@@ -212,21 +212,12 @@ architecture structure of MIPS_Processor is
             );
     end component;
 
-    component mux2t1 is
-        port (
-            i_S  : in  std_logic;
-            i_D0 : in  std_logic;
-            i_D1 : in  std_logic;
-            o_O  : out std_logic
-            );
-    end component;
-
     component dffg_N is
         port (
-            i_CLK : in  std_logic;                      
-            i_RST : in  std_logic;                      
-            i_WE  : in  std_logic;                      
-            i_D   : in  std_logic_vector(31 downto 0);  
+            i_CLK : in  std_logic;
+            i_RST : in  std_logic;
+            i_WE  : in  std_logic;
+            i_D   : in  std_logic_vector(31 downto 0);
             o_Q   : out std_logic_vector(31 downto 0)
             );
     end component;
@@ -267,17 +258,6 @@ architecture structure of MIPS_Processor is
             i_WB_wb     : in  std_logic;
             o_Forward_A : out std_logic_vector(1 downto 0);
             o_Forward_B : out std_logic_vector(1 downto 0)
-            );
-    end component;
-
-    component mux4t1_N is
-        port (
-            i_S  : in  std_logic_vector(1 downto 0);
-            i_D0 : in  std_logic_vector(N - 1 downto 0);
-            i_D1 : in  std_logic_vector(N - 1 downto 0);
-            i_D2 : in  std_logic_vector(N - 1 downto 0);
-            i_D3 : in  std_logic_vector(N - 1 downto 0);
-            o_O  : out std_logic_vector(N - 1 downto 0)
             );
     end component;
 
@@ -418,7 +398,7 @@ begin
             o_jump_branch => s_jump_branch
             );
 
-    instSignExtender: extender16t32
+    instSignExtender : extender16t32
         port map(
             i_C => s_signed,
             i_I => s_ID_Inst(15 downto 0),

--- a/src_sw/test-compile.do
+++ b/src_sw/test-compile.do
@@ -1,0 +1,6 @@
+vcom -2008 -work work ./proj/src/MIPS_types.vhd
+
+vcom -2008 -work work ./proj/src/LowLevel/*vhd
+vcom -2008 -work work ./proj/src/MidLevel/*vhd
+vcom -2008 -work work ./proj/src/TopLevel/*.vhd
+


### PR DESCRIPTION
- **Organize EXMEM ports**
- **improved BarrelShifter concisitity**
- **better naming for instances**
- **even better instancen names for the hardware implementation**
- **remove testing bash files**
- **update names of testbenches for pipeline stages**
- **remove pipeline testbenches as they are just dffgs now**
- **remove unused files**
- **better instance names in alu**
- **renamed testbench for register file**
- **ensure alu fits styleguide**
- **ensure AdderSubtractor fits styleguide**
- **better spacing in hazardunit and make sure it follows styleguide**
- **simplify forwardunit comment**
- **improve alu readability and formatting of complex logic**
- **finish cleaning up signal names in harware implementation**
- **add base tests**
- **update make file for software implementation**
- **fix full adder overflow**
- **added concurring test script**
- **remove test.sh**
- **upload new timing**
- **formate full_adder.vhd**
- **ensure mux2t1 fits styleguide**
- **make mux4t1 fit styleguide**
- **remove unused components from software implementation**
- **remove more unused components**
- **add test-compile.do**
- **finish presentation of pipeline stages in both hardware and software implementations and make sure adherence to styleguide**
- **fix no signal to rt and rd for id_ex**
- **fix name capitialization fo mux4t1_N**
- **remove unnecessary comments**
- **make nandg32 fit styleguide**
- **make norg32 fit styleguide**
- **make org2 fit styleguide**
- **make org32 fit styleguide**
- **make xorg2 fit styleguide**
- **mkae xorg32 fit styleguide**
- **mkae Pipeline_ID_EX fit styleguide**

<sub><a href="https://huly.app/guest/cpre381?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzUxMjBhOWQyZWY0Y2JjYzQ2ZWE5NGYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHViY29ubmVyLWNwcmUzODEtNjcyNTBhMGUtNWMwM2NlOGY1Zi02YmU0NzMifQ.lH-RzwlsKpmup4YL21DD92RdNBwpBltioY2vMgli4Qs">Huly&reg;: <b>PROJE-87</b></a></sub>